### PR TITLE
Remove runtime 23.08 ffmpeg extension

### DIFF
--- a/flatpak.list
+++ b/flatpak.list
@@ -21,4 +21,3 @@ app/org.gnome.Weather/x86_64/stable
 app/org.gnome.clocks/x86_64/stable
 app/org.gnome.font-viewer/x86_64/stable
 app/org.mozilla.firefox/x86_64/stable
-runtime/org.freedesktop.Platform.ffmpeg-full/x86_64/23.08


### PR DESCRIPTION
I don't really see why this needs to be explicitly installed. Currently this results in the ffmpeg extension being pinned, so if a user runs "flatpak uninstall --unused", it will not remove the extension. It can only be manually unpinned first.