### PR TITLE
Add a Distrobox GUI Managment Tool

### DIFF
--- a/flatpak.list
+++ b/flatpak.list
@@ -1,6 +1,7 @@
 app/app.fotema.Fotema/x86_64/stable
 app/com.mattjakeman.ExtensionManager/x86_64/stable
 app/io.bassi.Amberol/x86_64/stable
+app/io.github.dvlv.boxbuddyrs/x86_64/stable
 app/org.gnome.Boxes/x86_64/stable
 app/org.gnome.Calculator/x86_64/stable
 app/org.gnome.Calendar/x86_64/stable


### PR DESCRIPTION
BoxBuddy is an Distrobox GUI Managment tool that creates, installs, exports, removes, enters and installs package formats grafically and is a valuable addition for an Immutable Distro.